### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <!-- Dependencies -->
         <org.apache.commons.lang.version>2.6</org.apache.commons.lang.version>
-        <org.apache.commons.collections.version>3.2.1</org.apache.commons.collections.version>
+        <org.apache.commons.collections.version>3.2.2</org.apache.commons.collections.version>
         <org.apache.commons.beanutils.version>1.8.3</org.apache.commons.beanutils.version>
         <org.apache.commons.io.version>2.4</org.apache.commons.io.version>
         <org.apache.commons.compress.version>1.6</org.apache.commons.compress.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
